### PR TITLE
Updated font-awesome-rails to 4.3.0.0

### DIFF
--- a/wysiwyg-rails.gemspec
+++ b/wysiwyg-rails.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.version       = WYSIWYG::Rails::VERSION
 
   gem.add_dependency "railties", ">= 3.2", "< 5.0"
-  gem.add_dependency "font-awesome-rails", "= 4.2.0.0"
+  gem.add_dependency "font-awesome-rails", "~> 4.3.0.0"
 end

--- a/wysiwyg-rails.gemspec
+++ b/wysiwyg-rails.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.version       = WYSIWYG::Rails::VERSION
 
   gem.add_dependency "railties", ">= 3.2", "< 5.0"
-  gem.add_dependency "font-awesome-rails", "~> 4.3.0.0"
+  gem.add_dependency "font-awesome-rails", ">= 4.2.0.0"
 end


### PR DESCRIPTION
See : https://github.com/froala/wysiwyg-rails/issues/10

Also, I did not use `= 4.3.0.0` but `~> 4.3.0.0` instead, should help be more flexible while remaining safe from breaking changes from font-awesome (as the font-awesome-rails versionning seems to be onpar with font-awesome's one).