### PR TITLE
precompile assets (needed for rails_admin integration)

### DIFF
--- a/lib/wysiwyg-rails/engine.rb
+++ b/lib/wysiwyg-rails/engine.rb
@@ -1,6 +1,18 @@
 module WYSIWYG
   module Rails
     class Engine < ::Rails::Engine
+      initializer 'froala.assets.precompile', group: :all do |app|
+        app.config.assets.precompile += %W(
+          froala_editor.min.js
+          froala_editor_ie8.min.js
+          plugins/*.js
+          langs/*.js
+          froala_content.min.css
+          froala_editor.min.css
+          froala_style.min.css
+          themes/*.css
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
While doing RailsAdmin integration for Froala, I realized Froala's assets need to be fetch separately (https://github.com/playtato/rails_admin/commit/6b4a5e03af5e4032dbb7912d2ab8c11282f4bf87), instead of being required in asset manifest files like it's supposed to be. So this is my take.

The integration now works perfectly on my projects. I'll do some more tweeks on rails_admin side before submitting a pull request there. 