### PR TITLE
Fixes ability of requiring font-awesome assets

### DIFF
--- a/lib/wysiwyg-rails/engine.rb
+++ b/lib/wysiwyg-rails/engine.rb
@@ -1,3 +1,5 @@
+require "font-awesome-rails"
+
 module WYSIWYG
   module Rails
     class Engine < ::Rails::Engine


### PR DESCRIPTION
__Steps to reproduce the issue:__

* Create a brand new rails 4.2.4 app
* Create a rails route + controller + view that uses application layout
* Add `gem 'wysiwyg-rails'` to the `Gemfile`
* Following usage instructions (https://github.com/froala/wysiwyg-rails#usage):
  * Add require to the `application.js`
  * Add requires to the `application.css`
* Visit new route
* Exception thrown `couldn't find file 'font-awesome' with type 'text/css'`


The problem being that the `font-awesome-rails` assets are not included in asset search path (i.e `Rails.application.config.assets.paths`). The requirement of the dependency should fix this.

More details:
https://bibwild.wordpress.com/2013/02/27/gem-depends-on-rails-engine-gem-gotcha-need-explicit-require/