### PR TITLE
add link for Froala Editor (version 2) documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Then restart your web server if it was previously running.
 
 Congrats all is done!
 
+## Getting Started
+Gem version "2.0.0-rc.3" is up to date with [Froala Editor (version 2)](https://github.com/froala/wysiwyg-editor) - read the updated documentation for [how to initialize the editor](https://www.froala.com/wysiwyg-editor/v2.0/docs/migrate-from-v1#initialization) and other changes.
+
 ## License
 
 The `wysiwyg-rails` project is under MIT license.


### PR DESCRIPTION
- points users to updated documentation for version 2 of Froala Editor 