### PR TITLE
Remove asset precompile config initializer

### DIFF
--- a/lib/wysiwyg-rails/engine.rb
+++ b/lib/wysiwyg-rails/engine.rb
@@ -1,17 +1,6 @@
 module WYSIWYG
   module Rails
     class Engine < ::Rails::Engine
-      initializer 'froala.assets.precompile', group: :all do |app|
-        app.config.assets.precompile += %W(
-          froala_editor.min.js
-          plugins/*.js
-          languages/*.js
-          froala_editor.min.css
-          froala_style.min.css
-          plugins/*.css
-          themes/*.css
-        )
-      end
     end
   end
 end


### PR DESCRIPTION
This is unnecessary as an asset gem. As shown in the docs for `wysiwyg-rails` gem, these files are required in manifest files that are already part of a Rails applications' precompile config. There is no need to also precompile these files too which **causes a very large amount of files being generated** when running `rails assets:precompile` (an extra file for each due to GZ).

I'm able to update or include any other changes that are necessary, just let me know. Happy to help. This resolves #56 which should be reopened. Update: created a new issue in #83.

Fixes #83

