### PR TITLE
Enable support for Rails 7.1

### DIFF
--- a/wysiwyg-rails.gemspec
+++ b/wysiwyg-rails.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = WYSIWYG::Rails::VERSION
 
-  gem.add_dependency "railties", ">= 3.2.7", "< 7.1"
+  gem.add_dependency "railties", ">= 3.2.7", "< 8.0"
 end


### PR DESCRIPTION
Enables support for all Rails 7 minor releases by restricting dependency to below 8.0, which allows the gem to be installed on Rails 7.1, which was released two weeks ago.

This is inline with updates to support previous major Rails versions, which did not specify a minor release. Examples of previous `wysiwyg-rails.gemspec` changes after each release:
- Bump for Rails 5: https://github.com/froala/wysiwyg-rails/commit/889336ee8d293fbd7f4afc8f2841538413396879
- Bump for Rails 6: https://github.com/froala/wysiwyg-rails/commit/8b8c9eae1a60785e8acaad582cbc925023df1972
- Original for Rails 4: https://github.com/froala/wysiwyg-rails/commit/0f713c929e37dee4360204909d2ae3c45712518